### PR TITLE
fix: correct google send event

### DIFF
--- a/src/runtime/composables/usePixelGoogle.ts
+++ b/src/runtime/composables/usePixelGoogle.ts
@@ -176,8 +176,8 @@ export default function (input?: GoogleModuleOptions) {
       // gtag(<command>, <command parameters>);
 
       // eslint-disable-next-line no-inner-declarations
-      function gtag(...args: any[]) {
-        window.dataLayer.push(...args);
+      function gtag(command: string, ...args: any[]) {
+        window.dataLayer.push(arguments);
       }
 
       // https://developers.google.com/tag-platform/gtagjs/reference#event


### PR DESCRIPTION

before:
<img width="627" alt="Screenshot 2023-12-12 at 09 30 21" src="https://github.com/niklasfjeldberg/nuxt-multi-tracker/assets/12596485/e1588d44-0bf8-464e-8198-c49fc0d7acc1">


after:
<img width="558" alt="Screenshot 2023-12-12 at 09 30 37" src="https://github.com/niklasfjeldberg/nuxt-multi-tracker/assets/12596485/a0a3a91e-5cef-4807-acf5-0c1eaafc2c09">

source: https://github.com/johannschopplich/nuxt-gtag/blob/6cdae194094cfb421b2320d9fefaee49970f9f91/src/runtime/gtag.ts#L4

